### PR TITLE
Default CVar value change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+/.idea
 desktop.ini

--- a/cfg/sourcemod/zombieplague.cfg
+++ b/cfg/sourcemod/zombieplague.cfg
@@ -49,7 +49,7 @@ zp_level_system "1" // Enable level system [0-no // 1-yes]
 // ----------
 zp_level_health_ratio "10.0" // Health multiplier for each level [health += health_ratio*level]
 zp_level_speed_ratio "0.01" // Speed multiplier for each level [speed += speed_ratio*level]
-zp_level_gravity_ratio "0.01" // Gravity multiplier for each level [gravity += gravity_ratio*level]
+zp_level_gravity_ratio "-0.01" // Gravity multiplier for each level [gravity += gravity_ratio*level]
 zp_level_damage_ratio "0.1" // Damage multiplier for each level [damage *= damage_ratio*level+1.0]
 // ----------
 zp_level_hud "1" // Enable level hud [0-no // 1-yes]


### PR DESCRIPTION
zp_level_gravity ratio was positive, which resulted in stronger gravity for higher level players.